### PR TITLE
Support autoscalling hpa to agent permissions

### DIFF
--- a/helm/templates/agent.yaml
+++ b/helm/templates/agent.yaml
@@ -39,6 +39,7 @@ rules:
   - apps
   - batch
   - rbac.authorization.k8s.io
+  - autoscaling
   resources: 
   - pods
   - deployments
@@ -51,6 +52,7 @@ rules:
   - clusterrolebindings
   - serviceaccounts
   - nodes
+  - horizontalpodautoscalers
   verbs:
   - get
   - list
@@ -267,6 +269,7 @@ webhooks:
         - gitops.weave.works
         - kustomize.toolkit.fluxcd.io
         - helm.toolkit.fluxcd.io
+        - autoscaling
         resources:
         - namespaces
         - pods
@@ -293,6 +296,7 @@ webhooks:
         - kustomizations
         - helmreleases
         - ocirepositories
+        - horizontalpodautoscalers
     timeoutSeconds: 5
     failurePolicy: {{ .Values.failurePolicy }}
     admissionReviewVersions: ["v1", "v1beta1"]


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
**Closes**
https://github.com/weaveworks/policy-agent/issues/102


<!-- Describe what has changed in this PR -->
**What changed?**
I added autoscalling api group to the agent permission to support `horizontalpodautoscaler` kind

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**
To support policies targeting `horizontalpodautoscaler` resources 

<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**


<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**
Wrote a policy to target HPA resources and it worked fine 
<!--
Is it notable for release? e.g. schema updates or configuration required? If so, please mention it.
-->
**Release notes**


<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
