### PR TITLE
Use dev branch for release notes generation

### DIFF
--- a/.github/workflows/changelog_configuration.json
+++ b/.github/workflows/changelog_configuration.json
@@ -18,5 +18,8 @@
   ],
   "template": "${{CHANGELOG}}\n\n<details>\n<summary>Uncategorized</summary>\n\n${{UNCATEGORIZED}}\n</details>",
   "pr_template": "- PR: #${{NUMBER}} - ${{TITLE}}",
-    "empty_template": "- no changes"
+  "empty_template": "- no changes",
+  "base_branches": [
+      "dev"
+  ]
 }


### PR DESCRIPTION
Modify changelog configuration to generate release notes from PRs created against dev only to avoid duplication.