### PR TITLE
Set explicit versions for logger and opa-core in policy-core package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,9 +21,9 @@ require (
 	github.com/stretchr/testify v1.8.2
 	github.com/urfave/cli/v2 v2.24.4
 	github.com/weaveworks/policy-agent/api v1.0.5
-	github.com/weaveworks/policy-agent/pkg/logger v0.0.0-20230411202656-c275cc5de56f
+	github.com/weaveworks/policy-agent/pkg/logger v1.1.0
 	github.com/weaveworks/policy-agent/pkg/policy-core v0.0.0-20230411203714-bf53ac3f4945
-	github.com/weaveworks/policy-agent/pkg/uuid-go v0.0.0-20230411202656-c275cc5de56f
+	github.com/weaveworks/policy-agent/pkg/uuid-go v0.1.0
 	go.uber.org/zap v1.24.0
 	golang.org/x/sync v0.1.0
 	k8s.io/api v0.26.3
@@ -91,7 +91,7 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/subosito/gotenv v1.4.2 // indirect
 	github.com/tchap/go-patricia/v2 v2.3.1 // indirect
-	github.com/weaveworks/policy-agent/pkg/opa-core v0.0.0-20230411202656-c275cc5de56f // indirect
+	github.com/weaveworks/policy-agent/pkg/opa-core v1.1.0 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect

--- a/pkg/policy-core/go.mod
+++ b/pkg/policy-core/go.mod
@@ -2,19 +2,13 @@ module github.com/weaveworks/policy-agent/pkg/policy-core
 
 go 1.20
 
-replace (
-	github.com/weaveworks/policy-agent/pkg/logger => ../logger
-	github.com/weaveworks/policy-agent/pkg/opa-core => ../opa-core
-	github.com/weaveworks/policy-agent/pkg/uuid-go => ../uuid-go
-)
-
 require (
 	github.com/golang/mock v1.6.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/stretchr/testify v1.8.1
-	github.com/weaveworks/policy-agent/pkg/logger v0.0.0-20230411201136-3d0c79150c68
-	github.com/weaveworks/policy-agent/pkg/opa-core v0.0.0-20230411202038-cd1a97b35eda
-	github.com/weaveworks/policy-agent/pkg/uuid-go v0.0.0-20230411202038-cd1a97b35eda
+	github.com/weaveworks/policy-agent/pkg/logger v1.1.0
+	github.com/weaveworks/policy-agent/pkg/opa-core v1.1.0
+	github.com/weaveworks/policy-agent/pkg/uuid-go v0.1.0
 	k8s.io/api v0.26.3
 	k8s.io/apimachinery v0.26.3
 	sigs.k8s.io/kustomize/kyaml v0.14.1

--- a/pkg/policy-core/go.sum
+++ b/pkg/policy-core/go.sum
@@ -134,6 +134,12 @@ github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKs
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/tchap/go-patricia/v2 v2.3.1 h1:6rQp39lgIYZ+MHmdEq4xzuk1t7OdC35z/xm0BGhTkes=
 github.com/tchap/go-patricia/v2 v2.3.1/go.mod h1:VZRHKAb53DLaG+nA9EaYYiaEx6YztwDlLElMsnSHD4k=
+github.com/weaveworks/policy-agent/pkg/logger v1.1.0 h1:LwWacSwGApgqniM0wzBS1XcAE46Iu0mCeczQBeIA11M=
+github.com/weaveworks/policy-agent/pkg/logger v1.1.0/go.mod h1:bhlwMW3rcPE294XrmlDYvx4EkRCbAzEqXBT9LI4KIFA=
+github.com/weaveworks/policy-agent/pkg/opa-core v1.1.0 h1:++9oPP/cNuo2SUbBjFim1o0YM8g42kcNWgXMBCOdl7w=
+github.com/weaveworks/policy-agent/pkg/opa-core v1.1.0/go.mod h1:ZY18awHQq5tvh4lL9PvaRbP34qOIw709wGcKhtf6ZbI=
+github.com/weaveworks/policy-agent/pkg/uuid-go v0.1.0 h1:2zODdAnMFAgYhNJj/Oe59OxG98LWuFRxF7cIovPnSVE=
+github.com/weaveworks/policy-agent/pkg/uuid-go v0.1.0/go.mod h1:norQi1tZAienB1ad0kAbiJlTe85j+LVef5P53kW7qAo=
 github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb h1:zGWFAtiMcyryUHoUjUJX0/lt1H2+i2Ka2n+D3DImSNo=
 github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=


### PR DESCRIPTION
Set explicit versions of packages used by policy-core in preparation of tagging a new version of `policy-core`.