### PR TITLE
Remove tests from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,23 +20,6 @@ jobs:
           go-version: '1.20.x'
           cache: true
 
-      - name: Build binary
-        run: |
-          make build
-
-      - name: Running ElasticSearch
-        run: |
-          docker run -itd --name elasticsearch -p 9200:9200 -e "discovery.type=single-node" -e "xpack.security.enabled=false" docker.elastic.co/elasticsearch/elasticsearch:8.3.3
-          sleep 20
-          timeout 120 sh -c 'until nc -z $0 $1; do echo "waiting for elasticsearch to start on port 9200"; sleep 5; done' localhost 9200
-
-      - name: run test
-        env:
-          CODECOV_TOKEN: ${{secrets.CODECOV_TOKEN}}
-        run: |
-          make test
-          bash <(curl -s https://codecov.io/bash) -F unit
-
       - name: Build docker image
         run: |
           make image VERSION=${{  github.ref_name }}


### PR DESCRIPTION
Remove tests from the release workflows since `master` and `dev` are protected. 