### PR TITLE
Update dependabot configuration to only manage vulnerabilities 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,5 @@ updates:
       interval: "daily"
     reviewers:
       - "weaveworks/timber-wolf"
+    # Only do security updates not version updates.
+    open-pull-requests-limit: 0

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    reviewers:
+      - "weaveworks/timber-wolf"


### PR DESCRIPTION

<!-- Describe what has changed in this PR -->
**What changed?**

* Tweaking dependabot to just raise PRs for security updates not version updates. More info in https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit


<!-- Tell your future self why have you made these changes -->
**Why was this change made?**

Currently does both dependency management and vulnerability management. the original scope was vulnerability management. this PR reset that scope. 


<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**

Same did in other repos like [Weave Gitops OSS](https://github.com/weaveworks/weave-gitops/commit/f87bf964c84e383aea65707f317ca3b42a1daad6)


<!--
Is it notable for release? e.g. schema updates or configuration required? If so, please mention it.
-->
**Release notes**

Exclude


<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
