### PR TITLE
dependabot: only do security updates not version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,5 @@ updates:
       interval: "daily"
     reviewers:
       - "weaveworks/timber-wolf"
+    # Only do security updates not version updates.
+    open-pull-requests-limit: 0


### PR DESCRIPTION
**What changed?**

Tweaking dependabot to just raise PRs for security updates not version updates. More info in https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit

**Why was this change made?**

Currently does both dependency management and vulnerability management. the original scope was vulnerability management. this PR reset that scope.

**How did you validate the change?**

Same did in other repos like [Weave Gitops OSS](https://github.com/weaveworks/weave-gitops/commit/f87bf964c84e383aea65707f317ca3b42a1daad6)
